### PR TITLE
Added Elasticsearch images to system tests

### DIFF
--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -12,6 +12,11 @@ run docker pull postgres:9.5.1
 echo "Pulling kafka 0.10.1.0 with scala 2.11 image from public registry"
 run docker pull spotify/kafka@sha256:cf8f8f760b48a07fb99df24fab8201ec8b647634751e842b67103a25a388981b
 
+echo "Pulling elasticsearch images from public registry"
+run docker pull elasticsearch:1-alpine
+run docker pull elasticsearch:2-alpine
+run docker pull elasticsearch:5-alpine
+
 echo "Building base image"
 run docker build -t stests/base ./base
 

--- a/docker/opennms/scripts/bootstrap.sh
+++ b/docker/opennms/scripts/bootstrap.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 OPENNMS_HOME=/opt/opennms
 
 echo "OPENNMS HOME: "${OPENNMS_HOME}
@@ -6,6 +6,18 @@ echo "OPENNMS HOME: "${OPENNMS_HOME}
 # Point PostgreSQL to the linked container
 sed -i 's|url=.*opennms.*|url="jdbc:postgresql://'"${POSTGRES_PORT_5432_TCP_ADDR}:${POSTGRES_PORT_5432_TCP_PORT}/opennms"'"|g' "${OPENNMS_HOME}/etc/opennms-datasources.xml"
 sed -i 's|url=.*template1.*|url="jdbc:postgresql://'"${POSTGRES_PORT_5432_TCP_ADDR}:${POSTGRES_PORT_5432_TCP_PORT}/template1"'"|g' "${OPENNMS_HOME}/etc/opennms-datasources.xml"
+
+# Point Elasticsearch to the linked container
+cat > ${OPENNMS_HOME}/etc/org.opennms.features.elasticsearch.eventforwarder.cfg <<EOF
+elasticsearchIp=${ELASTICSEARCH_PORT_9200_TCP_ADDR}
+elasticsearchHttpPort=${ELASTICSEARCH_PORT_9200_TCP_PORT}
+elasticsearchTransportPort=${ELASTICSEARCH_PORT_9300_TCP_PORT}
+EOF
+
+# Point Elasticsearch REST to the linked container
+cat > ${OPENNMS_HOME}/etc/org.opennms.plugin.elasticsearch.rest.forwarder.cfg <<EOF
+elasticsearchUrl=http://${ELASTICSEARCH_PORT_9200_TCP_ADDR}:${ELASTICSEARCH_PORT_9200_TCP_PORT}
+EOF
 
 # Expose the Karaf shell
 sed -i s/sshHost.*/sshHost=0.0.0.0/g "${OPENNMS_HOME}/etc/org.apache.karaf.shell.cfg"

--- a/src/main/java/org/opennms/test/system/api/TestEnvironmentBuilder.java
+++ b/src/main/java/org/opennms/test/system/api/TestEnvironmentBuilder.java
@@ -164,6 +164,33 @@ public class TestEnvironmentBuilder {
         return this;
     }
 
+    public TestEnvironmentBuilder es1() {
+        if (m_containers.contains(ContainerAlias.ELASTICSEARCH_1)) {
+            return this;
+        }
+
+        m_containers.add(ContainerAlias.ELASTICSEARCH_1);
+        return this;
+    }
+
+    public TestEnvironmentBuilder es2() {
+        if (m_containers.contains(ContainerAlias.ELASTICSEARCH_2)) {
+            return this;
+        }
+
+        m_containers.add(ContainerAlias.ELASTICSEARCH_2);
+        return this;
+    }
+
+    public TestEnvironmentBuilder es5() {
+        if (m_containers.contains(ContainerAlias.ELASTICSEARCH_5)) {
+            return this;
+        }
+
+        m_containers.add(ContainerAlias.ELASTICSEARCH_5);
+        return this;
+    }
+
     public TestEnvironmentBuilder opennms() {
         if (m_containers.contains(ContainerAlias.OPENNMS)) {
             return this;


### PR DESCRIPTION
Add optional Elasticsearch 1.X, 2.X and 5.X containers to the system test framework.