### PR TITLE
Remove Elasticsearch 1.X support

### DIFF
--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -13,7 +13,6 @@ echo "Pulling kafka 0.10.1.0 with scala 2.11 image from public registry"
 run docker pull spotify/kafka@sha256:cf8f8f760b48a07fb99df24fab8201ec8b647634751e842b67103a25a388981b
 
 echo "Pulling elasticsearch images from public registry"
-run docker pull elasticsearch:1-alpine
 run docker pull elasticsearch:2-alpine
 run docker pull elasticsearch:5-alpine
 

--- a/src/main/java/org/opennms/test/system/api/NewTestEnvironment.java
+++ b/src/main/java/org/opennms/test/system/api/NewTestEnvironment.java
@@ -90,7 +90,6 @@ import com.spotify.docker.client.messages.PortBinding;
  *  <li>snmpd: An instance of Net-SNMP (used to test SNMP support)</li>
  *  <li>tomcat: An instance of Tomcat (used to test JMX support)</li>
  *  <li>kafka: An optional instance of Apache Kafka to test Minion's Kafka support</li>
- *  <li>elasticsearch1: An optional instance of Elasticsearch 1.X</li>
  *  <li>elasticsearch2: An optional instance of Elasticsearch 2.X</li>
  *  <li>elasticsearch5: An optional instance of Elasticsearch 5.X</li>
  * </ul>
@@ -106,7 +105,6 @@ public class NewTestEnvironment extends AbstractTestEnvironment implements TestE
      * Note that these are not the container IDs or names
      */
     public static enum ContainerAlias {
-        ELASTICSEARCH_1,
         ELASTICSEARCH_2,
         ELASTICSEARCH_5,
         KAFKA,
@@ -140,7 +138,6 @@ public class NewTestEnvironment extends AbstractTestEnvironment implements TestE
      */
     public static final ImmutableMap<ContainerAlias, String> IMAGES_BY_ALIAS =
             new ImmutableMap.Builder<ContainerAlias, String>()
-            .put(ContainerAlias.ELASTICSEARCH_1, "elasticsearch:1-alpine")
             .put(ContainerAlias.ELASTICSEARCH_2, "elasticsearch:2-alpine")
             .put(ContainerAlias.ELASTICSEARCH_5, "elasticsearch:5-alpine")
             .put(ContainerAlias.KAFKA, "spotify/kafka@sha256:cf8f8f760b48a07fb99df24fab8201ec8b647634751e842b67103a25a388981b")
@@ -211,7 +208,6 @@ public class NewTestEnvironment extends AbstractTestEnvironment implements TestE
         docker = DefaultDockerClient.fromEnv().build();
 
         spawnKafka();
-        spawnElasticsearch1();
         spawnElasticsearch2();
         spawnElasticsearch5();
 
@@ -379,10 +375,6 @@ public class NewTestEnvironment extends AbstractTestEnvironment implements TestE
         spawnContainer(alias, builder, Collections.emptyList());
     }
 
-    private void spawnElasticsearch1() throws DockerException, InterruptedException, IOException {
-        spawnElasticsearch(ContainerAlias.ELASTICSEARCH_1);
-    }
-
     private void spawnElasticsearch2() throws DockerException, InterruptedException, IOException {
         spawnElasticsearch(ContainerAlias.ELASTICSEARCH_2);
     }
@@ -479,9 +471,7 @@ public class NewTestEnvironment extends AbstractTestEnvironment implements TestE
         links.add(String.format("%s:postgres", containerInfoByAlias.get(ContainerAlias.POSTGRES).name()));
 
         // Link to the Elasticsearch container, if enabled
-        if (isEnabled(ContainerAlias.ELASTICSEARCH_1)) {
-            links.add(String.format("%s:elasticsearch", containerInfoByAlias.get(ContainerAlias.ELASTICSEARCH_1).name()));
-        } else if (isEnabled(ContainerAlias.ELASTICSEARCH_2)) {
+        if (isEnabled(ContainerAlias.ELASTICSEARCH_2)) {
             links.add(String.format("%s:elasticsearch", containerInfoByAlias.get(ContainerAlias.ELASTICSEARCH_2).name()));
         } else if (isEnabled(ContainerAlias.ELASTICSEARCH_5)) {
             links.add(String.format("%s:elasticsearch", containerInfoByAlias.get(ContainerAlias.ELASTICSEARCH_5).name()));

--- a/src/main/java/org/opennms/test/system/api/TestEnvironmentBuilder.java
+++ b/src/main/java/org/opennms/test/system/api/TestEnvironmentBuilder.java
@@ -195,15 +195,6 @@ public class TestEnvironmentBuilder {
         return this;
     }
 
-    public TestEnvironmentBuilder es1() {
-        if (m_containers.contains(ContainerAlias.ELASTICSEARCH_1)) {
-            return this;
-        }
-
-        m_containers.add(ContainerAlias.ELASTICSEARCH_1);
-        return this;
-    }
-
     public TestEnvironmentBuilder es2() {
         if (m_containers.contains(ContainerAlias.ELASTICSEARCH_2)) {
             return this;

--- a/src/main/java/org/opennms/test/system/api/TestEnvironmentBuilder.java
+++ b/src/main/java/org/opennms/test/system/api/TestEnvironmentBuilder.java
@@ -11,6 +11,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -141,8 +142,8 @@ public class TestEnvironmentBuilder {
     private static Logger LOG = LoggerFactory.getLogger(TestEnvironmentBuilder.class);
 
     private String m_name = null;
-    private boolean m_skipTearDown = false;
-    private boolean m_useExisting = false;
+
+    EnumMap<TestEnvironmentProperty,Object> properties = new EnumMap<>(TestEnvironmentProperty.class);
 
     private Set<ContainerAlias> m_containers = new LinkedHashSet<>();
 
@@ -154,12 +155,12 @@ public class TestEnvironmentBuilder {
     }
 
     public TestEnvironmentBuilder skipTearDown(boolean skipTearDown) {
-        m_skipTearDown = skipTearDown;
+        properties.put(TestEnvironmentProperty.SKIP_TEAR_DOWN, skipTearDown);
         return this;
     }
 
     public TestEnvironmentBuilder useExisting(boolean useExisting) {
-        m_useExisting = useExisting;
+        properties.put(TestEnvironmentProperty.USE_EXISTING, useExisting);
         return this;
     }
 
@@ -291,13 +292,13 @@ public class TestEnvironmentBuilder {
         }
 
         LOG.debug("Creating environment with containers: {}", m_containers);
-        if (m_useExisting) {
+        if ((Boolean)properties.get(TestEnvironmentProperty.USE_EXISTING)) {
             return new ExistingTestEnvironment();
         } else {
             final Path opennmsOverlay = (m_opennmsEnvironmentBuilder == null ? null : m_opennmsEnvironmentBuilder.build());
             final Path minionOverlay = (m_minionEnvironmentBuilder == null ? null : m_minionEnvironmentBuilder.build());
 
-            return new NewTestEnvironment(m_name, m_skipTearDown, opennmsOverlay, minionOverlay, m_containers);
+            return new NewTestEnvironment(m_name, properties, opennmsOverlay, minionOverlay, m_containers);
         }
     }
 }

--- a/src/main/java/org/opennms/test/system/api/TestEnvironmentProperty.java
+++ b/src/main/java/org/opennms/test/system/api/TestEnvironmentProperty.java
@@ -1,0 +1,18 @@
+package org.opennms.test.system.api;
+
+public enum TestEnvironmentProperty {
+    /**
+     * Set to true if the containers should be kept running after the tests complete
+     * (regardless of whether or not they were successful).
+     */
+    SKIP_TEAR_DOWN,
+    /**
+     * If set to true, do not initialize the Docker environment and use an existing
+     * OpenNMS environment instead.
+     */
+    USE_EXISTING,
+    /**
+     * Default number of partitions per topic in the Apache Kafka container.
+     */
+    KAFKA_PARTITIONS
+}


### PR DESCRIPTION
Elasticsearch 1.X is unsupported so this removes it from the test environment.