### PR TITLE
Add ability to fetch service address for ContainerInfo

### DIFF
--- a/src/main/java/org/opennms/test/system/api/AbstractTestEnvironment.java
+++ b/src/main/java/org/opennms/test/system/api/AbstractTestEnvironment.java
@@ -52,11 +52,16 @@ public abstract class AbstractTestEnvironment extends ExternalResourceRule imple
         if (info == null) {
             throw new IllegalArgumentException(String.format("No container found with alias: %s", alias));
         }
+        return getServiceAddress(info, port, type);
+    }
+
+    @Override
+    public InetSocketAddress getServiceAddress(ContainerInfo info, int port, String type) {
         final String portKey = port + "/" + type;
         final List<PortBinding> bindings = info.networkSettings().ports().get(portKey);
         if (bindings == null) {
             throw new IllegalArgumentException(String.format("No bindings found for port %s on alias: %s",
-                    portKey, alias));
+                    portKey, info.name()));
         }
         final PortBinding binding = bindings.iterator().next();
         final String host = "0.0.0.0".equals(binding.hostIp()) ? getDockerClient().getHost() : binding.hostIp();

--- a/src/main/java/org/opennms/test/system/api/TestEnvironment.java
+++ b/src/main/java/org/opennms/test/system/api/TestEnvironment.java
@@ -47,13 +47,15 @@ import com.spotify.docker.client.messages.ContainerInfo;
  */
 public interface TestEnvironment extends TestRule {
 
-    public InetSocketAddress getServiceAddress(ContainerAlias alias, int port);
+    InetSocketAddress getServiceAddress(ContainerAlias alias, int port);
 
-    public InetSocketAddress getServiceAddress(ContainerAlias alias, int port, String type);
+    InetSocketAddress getServiceAddress(ContainerAlias alias, int port, String type);
 
-    public ContainerInfo getContainerInfo(ContainerAlias alias);
+    InetSocketAddress getServiceAddress(ContainerInfo alias, int port, String type);
 
-    public Set<ContainerAlias> getContainerAliases();
+    ContainerInfo getContainerInfo(ContainerAlias alias);
+
+    Set<ContainerAlias> getContainerAliases();
 
     public static TestEnvironmentBuilder builder() {
         return new TestEnvironmentBuilder();


### PR DESCRIPTION
This allows us to fetch updated ContainerInfo instances and inspect them for service addresses instead of always using the cached values that are stored when spawning the container. This allows us to fetch correct service addresses from containers that have been restarted.