### PR TITLE
Only add the external ActiveMQ connector once

### DIFF
--- a/docker/opennms/scripts/bootstrap.sh
+++ b/docker/opennms/scripts/bootstrap.sh
@@ -28,14 +28,17 @@ EOF
 sed -i s/sshHost.*/sshHost=0.0.0.0/g "${OPENNMS_HOME}/etc/org.apache.karaf.shell.cfg"
 
 # Expose ActiveMQ
-# Search for the <transportConnectors> tag and insert the externally accessible connector after it
-echo "Editing opennms-activemq.xml..."
-ed "${OPENNMS_HOME}/etc/opennms-activemq.xml" <<EOF
+grep '<transportConnector name="openwire" uri="tcp://0.0.0.0:61616' /opt/opennms/etc/opennms-activemq.xml | grep -v '<!--' >/dev/null
+if [ $? != 0 ]; then
+	# Search for the <transportConnectors> tag and insert the externally accessible connector after it
+	echo "Editing opennms-activemq.xml..."
+	ed "${OPENNMS_HOME}/etc/opennms-activemq.xml" <<EOF
 /<transportConnectors>/a
 <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?useJmx=false&amp;maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/>
 .
 wq
 EOF
+fi
 
 #echo "Editing custom.properties..."
 #ed "${OPENNMS_HOME}/etc/custom.properties" <<EOF


### PR DESCRIPTION
Without this, the OpenNMS container will fail to restart correctly.