### PR TITLE
HZN-1249: Let tests define elasticsearch properly

### DIFF
--- a/docker/opennms/scripts/bootstrap.sh
+++ b/docker/opennms/scripts/bootstrap.sh
@@ -15,9 +15,11 @@ elasticsearchTransportPort=${ELASTICSEARCH_PORT_9300_TCP_PORT}
 EOF
 
 # Point Elasticsearch REST to the linked container
+if [ -ne ${OPENNMS_HOME}/etc/org.opennms.plugin.elasticsearch.rest.forwarder.cfg ]; then
 cat > ${OPENNMS_HOME}/etc/org.opennms.plugin.elasticsearch.rest.forwarder.cfg <<EOF
 elasticsearchUrl=http://${ELASTICSEARCH_PORT_9200_TCP_ADDR}:${ELASTICSEARCH_PORT_9200_TCP_PORT}
 EOF
+fi
 
 # Point the Apache Kafka sink to the linked container
 mkdir -p "${OPENNMS_HOME}/etc/opennms.properties.d"


### PR DESCRIPTION
The `bootstrap.sh` originally defines the `elasticsearchUrl` of the `opennms-es-rest` plugin. That property was changed to `elasticUrl` in https://issues.opennms.org/HZN-1249. Therefore the property does not exist anymore.

The tests using that plugin, define according properties, after the container started.
However some tests perform a restart of the container, overwriting the existing configuration with the default one.

In general, the test should provide appropriate configuration, thus the PR.