### PR TITLE
Fix NPE when determing links for minion container if opennms, snmpd or tomcat container is not available

### DIFF
--- a/src/main/java/org/opennms/test/system/api/NewTestEnvironment.java
+++ b/src/main/java/org/opennms/test/system/api/NewTestEnvironment.java
@@ -735,10 +735,15 @@ public class NewTestEnvironment extends AbstractTestEnvironment implements TestE
             binds.add(minionKarafLogs.toString() + ":/opt/minion/data/log");
 
             final List<String> links = Lists.newArrayList();
-            links.add(String.format("%s:opennms", containerInfoByAlias.get(ContainerAlias.OPENNMS).name()));
-            links.add(String.format("%s:snmpd", containerInfoByAlias.get(ContainerAlias.SNMPD).name()));
-            links.add(String.format("%s:tomcat", containerInfoByAlias.get(ContainerAlias.TOMCAT).name()));
-
+            if (isEnabled(ContainerAlias.OPENNMS)) {
+                links.add(String.format("%s:opennms", containerInfoByAlias.get(ContainerAlias.OPENNMS).name()));
+            }
+            if (isEnabled(ContainerAlias.SNMPD)) {
+                links.add(String.format("%s:snmpd", containerInfoByAlias.get(ContainerAlias.SNMPD).name()));
+            }
+            if (isEnabled(ContainerAlias.TOMCAT)) {
+                links.add(String.format("%s:tomcat", containerInfoByAlias.get(ContainerAlias.TOMCAT).name()));
+            }
             if (isEnabled(ContainerAlias.KAFKA)) {
                 links.add(String.format("%s:kafka", containerInfoByAlias.get(ContainerAlias.KAFKA).name()));
             }


### PR DESCRIPTION
While I was working on a system test including sentinel, I got a weird non saying `NPE` when investigating, I found out, that the minion container expects OpenNMS, Tomcat and SNMPD containers to be running, which might not be the case. 

This PR ensures, that spawning a minion is possible if any of the above containers is not available.