### PR TITLE
Set sentinel http and broker urls properly

### DIFF
--- a/docker/sentinel/scripts/bootstrap.sh
+++ b/docker/sentinel/scripts/bootstrap.sh
@@ -10,6 +10,10 @@ sed -i s/sshHost.*/sshHost=0.0.0.0/g "${SENTINEL_HOME}/etc/org.apache.karaf.shel
 sed -i s/rmiRegistryHost.*/rmiRegistryHost=0.0.0.0/g "${SENTINEL_HOME}/etc/org.apache.karaf.management.cfg"
 sed -i s/rmiServerHost.*/rmiServerHost=0.0.0.0/g "${SENTINEL_HOME}/etc/org.apache.karaf.management.cfg"
 
+# Configure basic connection to opennms
+echo "http-url = http://${OPENNMS_PORT_8980_TCP_ADDR}:${OPENNMS_PORT_8980_TCP_PORT}/opennms" >> ${SENTINEL_HOME}/etc/org.opennms.sentinel.controller.cfg
+echo "broker-url = failover:tcp://${OPENNMS_PORT_61616_TCP_ADDR}:${OPENNMS_PORT_61616_TCP_PORT}" >> ${SENTINEL_HOME}/etc/org.opennms.sentinel.controller.cfg
+
 # Point the Apache Kafka sink to the linked container
 cat > ${SENTINEL_HOME}/etc/org.opennms.core.ipc.sink.kafka.cfg <<EOF
 bootstrap.servers=${KAFKA_PORT_9092_TCP_ADDR}:${KAFKA_PORT_9092_TCP_PORT}


### PR DESCRIPTION
Here we set the broker and http url for communication with OpenNMS via ActiveMQ and the RestClient.